### PR TITLE
Refactor layout with shared navigation

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -3,30 +3,8 @@
 export default function Home() {
   return (
     <>
-      <nav className="flex items-center w-full px-8">
-        {/* Bloco da esquerda - 70% largura */}
-        <div className="w-[70%]">
-          <span className="font-bold text-lg">Setos</span>
-        </div>
-
-        {/* Bloco da direita - 30% largura com links espaçados */}
-        <div className="w-[30%] flex justify-end space-x-8">
-          <a href="#" className="text-inherit no-underline hover:underline">
-            Services
-          </a>
-          <a href="#" className="text-inherit no-underline hover:underline">
-            Pricing
-          </a>
-          <a href="#" className="text-inherit no-underline hover:underline">
-            Features
-          </a>
-          <a href="#" className="text-inherit no-underline hover:underline">
-            About us
-          </a>
-        </div>
-      </nav>
-
-      <div>
+      <main>
+        <div>
         <div className="grid">
           <svg
             className="grid-svg"
@@ -165,12 +143,7 @@ export default function Home() {
           </g>
         </svg>
       </div>
-
-      <footer>
-        <p className="self-end pr-8 text-[hsl(155,100%,65%)]">TOS</p>
-        <p className="self-end pr-8 text-[hsl(155,100%,65%)]">Privacy Policy</p>
-        <p className="self-end pr-8 text-[hsl(155,100%,65%)]">Contact Us</p>
-      </footer>
+      </main>
 
       <style jsx global>{`
         @import url("https://fonts.googleapis.com/css?family=Manrope:700|Manrope:400");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@
 
 import { ReactNode } from 'react';
 import './globals.css';
+import NavBar from '@/components/NavBar';
+import Footer from '@/components/Footer';
 
 type RootProps = {
   children: ReactNode;
@@ -11,7 +13,9 @@ export default function RootLayout({ children }: RootProps) {
   return (
     <html lang="pt-BR">
       <body>
+        <NavBar />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer className="flex justify-center gap-8 py-4">
+      <p className="text-[hsl(155,100%,65%)]">TOS</p>
+      <p className="text-[hsl(155,100%,65%)]">Privacy Policy</p>
+      <p className="text-[hsl(155,100%,65%)]">Contact Us</p>
+    </footer>
+  );
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+
+export default function NavBar() {
+  return (
+    <nav className="flex w-full items-center px-8">
+      <div className="w-[70%]">
+        <span className="text-lg font-bold">Setos</span>
+      </div>
+      <div className="flex w-[30%] justify-end space-x-8">
+        <Link href="#" className="no-underline text-inherit hover:underline">
+          Services
+        </Link>
+        <Link href="#" className="no-underline text-inherit hover:underline">
+          Pricing
+        </Link>
+        <Link href="#" className="no-underline text-inherit hover:underline">
+          Features
+        </Link>
+        <Link href="#" className="no-underline text-inherit hover:underline">
+          About us
+        </Link>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared `NavBar` and `Footer` components
- include nav and footer in `RootLayout`
- clean up home page markup and keep style section

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687817e62770832c888535a1fe71fc94